### PR TITLE
Filtering fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EventRasters"
 uuid = "3d9f1ba8-ff48-11e8-3a02-0b3de68f1194"
 authors = ["Roger Herikstad <roger.herikstad@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/src/EventRasters.jl
+++ b/src/EventRasters.jl
@@ -61,7 +61,7 @@ function Base.filter(pred, raster::Raster)
 	tidx = findall(pred, unique(raster.trialidx))
 	events = raster.events[qidx]
 	tmin, tmax = extrema(events)
-	Raster(events, raster.trialidx[qidx], raster.markers[tidx], tmin, tmax)
+	Raster(events, raster.trialidx[qidx], raster.markers, tmin, tmax)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,5 +94,5 @@ end
 	uraster = filter(in([1,3]), raster)
 	@test uraster.events ≈ [0.0,0.2,0.1]
 	@test uraster.trialidx == [1,1,3]
-	@test uraster.markers == [1,3]
+	@test uraster.markers == [1,2,3]
 end


### PR DESCRIPTION
We should always have raster.markers[raster.trialidx] return the trial markers used for the raster. This fixes a bug where this was not true for filtered rasters.